### PR TITLE
Merge upstream repo updates

### DIFF
--- a/rally_plugins/services/kube/kube.py
+++ b/rally_plugins/services/kube/kube.py
@@ -17,13 +17,13 @@ import re
 
 from kubernetes import client as k8s_config
 from kubernetes.client import api_client
-from kubernetes.client.apis import batch_v1_api
-from kubernetes.client.apis import core_v1_api
-from kubernetes.client.apis import apps_v1_api
-from kubernetes.client.apis import extensions_v1beta1_api
-from kubernetes.client.apis import version_api
+from kubernetes.client.api import apps_v1_api
+from kubernetes.client.api import batch_v1_api
+from kubernetes.client.api import core_v1_api
+from kubernetes.client.api import extensions_v1beta1_api
+from kubernetes.client.api import storage_v1_api
+from kubernetes.client.api import version_api
 from kubernetes.client import rest
-from kubernetes.client.apis import storage_v1_api
 from kubernetes.stream import stream
 from rally.common import cfg
 from rally.common import logging
@@ -168,24 +168,7 @@ class Kubernetes(service.Service):
                                          name_generator=name_generator,
                                          atomic_inst=atomic_inst)
         self._spec = spec
-
-        # NOTE(andreykurilin): KubernetesClient doesn't provide any __version__
-        #   property to identify the client version (you are welcome to fix
-        #   this code if I'm wrong). Let's check for some backward incompatible
-        #   changes to identify the way to communicate with it.
-        if hasattr(k8s_config, "ConfigurationObject"):
-            # Actually, it is `k8sclient < 4.0.0`, so it can be
-            #   kubernetesclient 2.0 or even less, but it doesn't make any
-            #   difference for us
-            self._k8s_client_version = 3
-        else:
-            self._k8s_client_version = 4
-
-        if self._k8s_client_version == 3:
-            config = k8s_config.ConfigurationObject()
-        else:
-            config = k8s_config.Configuration()
-
+        config = k8s_config.Configuration.get_default_copy()
         config.host = self._spec["server"]
         config.ssl_ca_cert = self._spec["certificate-authority"]
         if self._spec.get("api_key"):
@@ -198,15 +181,10 @@ class Kubernetes(service.Service):
             config.key_file = self._spec["client-key"]
             if self._spec.get("tls_insecure", False):
                 config.verify_ssl = False
-
         if self._spec.get("disable_assert_hostname") is True:
             config.assert_hostname = False
 
-        if self._k8s_client_version == 3:
-            api = api_client.ApiClient(config=config)
-        else:
-            api = api_client.ApiClient(configuration=config)
-
+        api = api_client.ApiClient(configuration=config)
         self.api = api
         self.v1_client = core_v1_api.CoreV1Api(api)
         self.v1_storage = storage_v1_api.StorageV1Api(api)
@@ -226,7 +204,7 @@ class Kubernetes(service.Service):
             return {}
 
         kube_config.load_kube_config()
-        k8s_cfg = k8s_config.Configuration()
+        k8s_cfg = k8s_config.Configuration.get_default_copy()
         return {
             "host": k8s_cfg.host,
             "certificate-authority": k8s_cfg.ssl_ca_cert,

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ setuptools-scm                                         # MIT
 rally>=0.11.0
 rally-openstack
 requests>=2.14.2                                       # Apache License, Version 2.0
-kubernetes>=5.0.0                                       # Apache License Version 2.0
+kubernetes>=12.0.0                                      # Apache License Version 2.0


### PR DESCRIPTION
Update the Configuration logic for kubernetes v12.0.0

As highlighted by [1], kubernetes v12.0.0 and newer asks for the use of
Configuration.get_default_copy() [2]. It also removes the deprecated
backward compatibility and then forces kubernetes >= 12.0.0.

It also renames a few imports as warned by 12.0.0 and older.

[1] https://github.com/kubernetes-client/python/issues/1284
[2] https://github.com/kubernetes-client/python/commit/b4d11b02a3479e63957a729614a616002f13e9c4#diff-59aff6ce4d28aa662f8b411b9d0dfe4f3e949c32a5edaf8e08905b58e7a41ee3L69-R71